### PR TITLE
Update icinga2-commands.conf

### DIFF
--- a/contrib/icinga2-commands.conf
+++ b/contrib/icinga2-commands.conf
@@ -31,8 +31,8 @@ object CheckCommand "cloud_gcp_instance" {
         }
     }
 
-    vars.cloud_gcp_compute = "compute"
-    vars.cloud_gcp_instance = "instance"
+    vars.cloud_gcp_compute = ""
+    vars.cloud_gcp_instance = ""
 }
 
 object CheckCommand "cloud_gcp_instances" {
@@ -61,8 +61,8 @@ object CheckCommand "cloud_gcp_instances" {
         }
     }
 
-    vars.cloud_gcp_compute = "compute"
-    vars.cloud_gcp_instances = "instances"
+    vars.cloud_gcp_compute = ""
+    vars.cloud_gcp_instances = ""
 }
 
 apply Service "cloud_gcp_single_instance" {


### PR DESCRIPTION
use empty values for command verb arguments to avoid duplication of verbs on the command line at execution time

Hi there, I found this as part of my trial setup using icinga2 playground. Using the empty values for command verb arguments I am able to successfully run the check command as part of my setup. Before applying the suggested changes the command line execution failed with spurious error messages. Analyzing the logs I found that the command verbs (e.g. "compute" and "instances")  were duplicated on execution. 